### PR TITLE
Add tenfold's customizations and notes to Nami latest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .buildpath
 build
 src/node_modules
+.idea

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "author": "Marcelo Gornstein <marcelog@gmail.com> (http://marcelog.github.com/)",
-  "name": "nami",
-  "description": "An asterisk manager interface client, uses EventEmitter to communicate events, will allow you to send actions, and receive responses (and associated events), and also receive async events from server",
+  "author": "Marcelo Gornstein <marcelog@gmail.com> (http://marcelog.github.com)",
+  "name": "nami-raw-callinize",
+  "description": "Minor fork of NAMI.  It adds a raw event emitter and ability to subscribe to events on connect, sets keepalive.  Original Description: An asterisk manager interface client, uses EventEmitter to communicate events, will allow you to send actions, and receive responses (and associated events), and also receive async events from server",
   "version": "0.7.2",
-  "homepage": "https://github.com/marcelog/Nami",
+  "homepage": "https://github.com/callinize/Nami",
   "keywords": [
     "asterisk",
     "manager",
@@ -14,9 +14,31 @@
     "event",
     "node"
   ],
+  "contributors": [
+    {
+      "name": "Marcelo Gornstein",
+      "email": "marcelog@gmail.com",
+      "url": "http://marcelog.github.com"
+    },
+    {
+      "name": "Blake Robertson",
+      "email": "dev@tenfold.com",
+      "url": "http://www.tenfold.com"
+    },
+    {
+      "name": "Patrick Hogan",
+      "email": "dev@tenfold.com",
+      "url": "http://www.tenfold.com"
+    },
+    {
+      "name": "Rhaylander Almeida",
+      "email": "dev@tenfold.com",
+      "url": "http://www.tenfold.com"
+    }
+  ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/marcelog/Nami.git"
+    "url": "git://github.com/callinize/Nami.git"
   },
   "main": "src/nami",
   "scripts": {

--- a/src/message/action.js
+++ b/src/message/action.js
@@ -52,14 +52,18 @@ var ActionUniqueId = (function() {
  * @constructor
  * @param {String} username The username. The value of the "Username" key.
  * @param {String} secret The password. The value of the "Secret" key.
+ * @param {String} events a comma delimited list of Events to subscribe to.  Example: "call,hud" will subscribe to all call and hud events.
  * @see Action(String)
  * @see See <a href="https://wiki.asterisk.org/wiki/display/AST/ManagerAction_Login">https://wiki.asterisk.org/wiki/display/AST/ManagerAction_Login</a>.
  * @augments Action
  */
-function Login(username, secret) {
+function Login(username, secret, events) {
     Login.super_.call(this, 'Login');
     this.set('Username', username);
     this.set('Secret', secret );
+    if( events !== undefined ) {
+        this.set('Events', events);
+    }
 }
 /**
  * CoreShowChannels Action.


### PR DESCRIPTION
callinize/callinize-node-server#9358

The issue was happening because Asterisk 13 uses AMI version greater than 2 and the version of the library we're using right now has a regex blocking the AMI version. The latest version of the library has it fixed. The regex is located in the file `src/nami.js#L61`.
- Old version: `this.welcomeMessage = "Asterisk Call Manager/(1\\.[0-3]|2\\.\\d\\.\\d)" + this.EOL;`
- New version: `this.welcomeMessage = "Asterisk Call Manager/.*" + this.EOL;`

The other thing that changed was the logger. In the version we're using someone hardcoded the logger inside of the library to use our logger:
- `var logger = require('../../../logger');`

The new version has an implementation to receive it amongst its parameters, which is easier and a better approach. So, in the PR to upgrade the version on `callinize/callinize-node-server` I'll also update the current code to pass the logger strategy as a parameter.

Other than that, the other changes are copies from the customized version we're using (even the comments). The library update also brings more Actions and flexibility when using some of them.